### PR TITLE
updates documentation on authentication

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -40,7 +40,7 @@ Direct uses API keys to allow access to the API. You can register a new Direct A
 
 Direct expects for the API key to be included in all API requests to the server in a header that looks like the following:
 
-`Authorization: your_api_key`
+`Authorization: Token your_api_key`
 
 `Accept: application/vnd.direct.v1`
 


### PR DESCRIPTION
We seem to get some problems with some people not including Token in their Authorization header, so I made that more explicit in the docs, like so;
<img width="1553" alt="Screenshot 2023-08-28 at 2 14 46 PM" src="https://github.com/vaystays/api/assets/38737341/bb4a6c3e-6aae-4a5d-8d19-72c64de90c4a">

**Testing Instructions:**
```shell
bundle install
bundle exec middleman server
```
Go to http://localhost:4567/#authentication and verify the changes made to the Authentication instructions